### PR TITLE
FIX(core): fix getting page from user object

### DIFF
--- a/packages/core/libs/api/NotionUser.ts
+++ b/packages/core/libs/api/NotionUser.ts
@@ -66,7 +66,7 @@ class NotionUser extends Data<INotionUser> {
     return (await this.createSpaces([opt]))[0];
   };
 
-  // ? FEAT:1:H Take root pages to create as parameter 
+  // ? FEAT:1:H Take root pages to create as parameter
   async createSpaces(opts: ISpaceCreateInput[]) {
     const metadata = {
       created_by_id: this.user_id,
@@ -106,7 +106,7 @@ class NotionUser extends Data<INotionUser> {
         shard_id: this.Operations.shard_id,
         icon,
       } as any;
-      
+
       const space_view_data: ISpaceView = {
         created_getting_started: false,
         created_onboarding_templates: false,
@@ -196,7 +196,7 @@ class NotionUser extends Data<INotionUser> {
     }, (child_id) => this.cache.space.get(child_id), (id, _,__,spaces)=>spaces.push(new Space({ ...this.getProps(), id })))
   }
 
-  // FIX:1:H How will deleting a space manipulate the internal cache 
+  // FIX:1:H How will deleting a space manipulate the internal cache
   async deleteSpace(arg: FilterType<ISpace>) {
     (await this.deleteSpaces(transformToMultiple(arg), false));
   }
@@ -226,11 +226,13 @@ class NotionUser extends Data<INotionUser> {
     for (let index = 0; index < ids.length; index++) {
       const id = idToUuid(uuidToId(ids[index])), page = this.cache.block.get(id) as TPage;
       if (page.type === "page") {
-        const page_obj = new Page({ ...this.getProps(), id: page.id })
+        const page_obj = new Page({ ...this.getProps(), id: page.id, space_id: page.space_id, shard_id: page.shard_id });
         page_map.page.set(page.id, page_obj)
         page_map.page.set(page.properties.title[0][0], page_obj);
         await this.initializeCacheForSpecificData(page.id, "block");
       } else if (page.type === "collection_view_page"){
+        await this.initializeCacheForSpecificData(id, 'block');
+        const cvp_obj = new CollectionViewPage({ ...this.getProps(), id: page.id, space_id: page.space_id, shard_id: page.shard_id });
         const cvp_obj = new CollectionViewPage({ ...this.getProps(), id: page.id });
         const collection = this.cache.collection.get(page.collection_id) as ICollection;
         page_map.collection_view_page.set(collection.name[0][0], cvp_obj);

--- a/packages/core/libs/api/NotionUser.ts
+++ b/packages/core/libs/api/NotionUser.ts
@@ -236,7 +236,6 @@ class NotionUser extends Data<INotionUser> {
         const collection = this.cache.collection.get(page.collection_id) as ICollection;
         page_map.collection_view_page.set(collection.name[0][0], cvp_obj);
         page_map.collection_view_page.set(page.id, cvp_obj);
-        await this.initializeCacheForSpecificData(page.id, "block");
       }
       else
         throw new UnsupportedBlockTypeError((page as any).type,['page', 'collection_view_page'])

--- a/packages/core/libs/api/NotionUser.ts
+++ b/packages/core/libs/api/NotionUser.ts
@@ -233,7 +233,6 @@ class NotionUser extends Data<INotionUser> {
       } else if (page.type === "collection_view_page"){
         await this.initializeCacheForSpecificData(id, 'block');
         const cvp_obj = new CollectionViewPage({ ...this.getProps(), id: page.id, space_id: page.space_id, shard_id: page.shard_id });
-        const cvp_obj = new CollectionViewPage({ ...this.getProps(), id: page.id });
         const collection = this.cache.collection.get(page.collection_id) as ICollection;
         page_map.collection_view_page.set(collection.name[0][0], cvp_obj);
         page_map.collection_view_page.set(page.id, cvp_obj);

--- a/packages/core/libs/createBlockClass.ts
+++ b/packages/core/libs/createBlockClass.ts
@@ -94,7 +94,8 @@ export function createBlockClass (type: TBlockType, id: string, props: Omit<Nish
 				'toggle',
 				'quote',
 				'divider',
-				'callout'
+				'callout',
+				'embed'
 			]);
 	}
 }

--- a/packages/core/libs/createBlockClass.ts
+++ b/packages/core/libs/createBlockClass.ts
@@ -44,6 +44,7 @@ export function createBlockClass (type: TBlockType, id: string, props: Omit<Nish
 		case 'quote':
 		case 'divider':
 		case 'callout':
+		case 'embed':
 			// All these data types belongs to the block type
 			// dynamically loading the Block class
 			const Block = require('./api/Block/Block').default;

--- a/packages/core/tests/api/NotionUser.test.ts
+++ b/packages/core/tests/api/NotionUser.test.ts
@@ -276,7 +276,7 @@ describe('NotionUser', () => {
         collection_view: new Map([['collection_view_1', { id: 'collection_view_1' } as any]]),
       },
         stack: IOperation[] = [];
-  
+
       const notion_user = new NotionUser({
         cache,
         id: 'user_root_1',
@@ -287,15 +287,15 @@ describe('NotionUser', () => {
         token: 'token',
         user_id: 'user_root_1'
       });
-  
+
       const initializeCacheForSpecificDataMock = jest
         .spyOn(NotionData.prototype, 'initializeCacheForSpecificData')
         .mockImplementationOnce(() => {
           return {} as any;
         });
-  
+
       const page_map = await notion_user.getPagesById([block_1_id, block_2_id]);
-      expect(initializeCacheForSpecificDataMock).toHaveBeenCalledTimes(2);
+      expect(initializeCacheForSpecificDataMock).toHaveBeenCalledTimes(3);
       expect(initializeCacheForSpecificDataMock).toHaveBeenNthCalledWith(1, block_1_id, 'block');
       expect(initializeCacheForSpecificDataMock).toHaveBeenNthCalledWith(2, block_2_id, 'block');
       expect((page_map.page.get(block_1_id) as Page).getCachedData()).toStrictEqual(block_1);
@@ -313,7 +313,7 @@ describe('NotionUser', () => {
           [block_1_id, block_1]
         ]),
       };
-  
+
       const notion_user = new NotionUser({
         cache,
         id: 'user_root_1',
@@ -324,7 +324,7 @@ describe('NotionUser', () => {
         token: 'token',
         user_id: 'user_root_1'
       });
-  
+
       await expect(notion_user.getPagesById([block_1_id])).rejects.toThrow();
     });
   })

--- a/packages/core/tests/api/NotionUser.test.ts
+++ b/packages/core/tests/api/NotionUser.test.ts
@@ -295,7 +295,7 @@ describe('NotionUser', () => {
         });
 
       const page_map = await notion_user.getPagesById([block_1_id, block_2_id]);
-      expect(initializeCacheForSpecificDataMock).toHaveBeenCalledTimes(3);
+      expect(initializeCacheForSpecificDataMock).toHaveBeenCalledTimes(2);
       expect(initializeCacheForSpecificDataMock).toHaveBeenNthCalledWith(1, block_1_id, 'block');
       expect(initializeCacheForSpecificDataMock).toHaveBeenNthCalledWith(2, block_2_id, 'block');
       expect((page_map.page.get(block_1_id) as Page).getCachedData()).toStrictEqual(block_1);


### PR DESCRIPTION
Fixes a "PostgresError" error from Notion API. These are the fixes from this week. For good measure, I also tried adding "await this.initializeCacheForSpecificData(id, 'block');" in getPagesById() when the type is "page" but that resulted in an error. 