### PR TITLE
add required fields to request collection data

### DIFF
--- a/packages/cache/libs/initializeCacheForSpecificData.ts
+++ b/packages/cache/libs/initializeCacheForSpecificData.ts
@@ -110,7 +110,7 @@ export async function initializeCacheForSpecificData (id: string, type: TDataTyp
 							type: 'table',
 							loadContentCover: false,
 							limit: 5000,
-							userTimeZone: 'UTC'
+							userTimeZone: ''
 						}
 					},
 					options

--- a/packages/cache/libs/initializeCacheForSpecificData.ts
+++ b/packages/cache/libs/initializeCacheForSpecificData.ts
@@ -107,7 +107,10 @@ export async function initializeCacheForSpecificData (id: string, type: TDataTyp
 						collectionViewId: '',
 						query: {},
 						loader: {
-							type: 'table'
+							type: 'table',
+							loadContentCover: false,
+							limit: 5000,
+							userTimeZone: 'UTC'
 						}
 					},
 					options


### PR DESCRIPTION

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix - in the past 24 hours, I noticed I Was receiving 400 "Invalid Input" from Notion during a background process which calls `collection.getRows()`. The only way I can get it to work now is by including some values for these fields. The 5000 is arbitrary, and not sure what the impact of passing an empty string for `userTimeZone` might be. Another option might be "UTC".