### PR TITLE
dont require page title to retrieve a notion page

### DIFF
--- a/packages/core/libs/Api/Nishan.ts
+++ b/packages/core/libs/Api/Nishan.ts
@@ -127,10 +127,12 @@ export default class Nishan {
           space_id: page.space_id
         });
         page_map.page.set(page.id, page_obj);
-        page_map.page.set(
-          NotionUtils.extractInlineBlockContent(page.properties.title),
-          page_obj
-        );
+        if (page.properties) {
+          page_map.page.set(
+            NotionUtils.extractInlineBlockContent(page.properties.title),
+            page_obj
+          );
+        }
       } else if (page.type === 'collection_view_page') {
         const cvp_obj = new NotionCore.Api.CollectionViewPage({
           ...this.getProps(),


### PR DESCRIPTION
If I try to retrieve a page that doesn't have title set, then `page.properties` is undefined, causing an error. Just checking for properties seems to fix it for me.